### PR TITLE
Add camera metadata and expose via API responses

### DIFF
--- a/frigate/api/fastapi_app.py
+++ b/frigate/api/fastapi_app.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Optional
 
@@ -91,6 +92,49 @@ def create_fastapi_app(
         # After request https://stackoverflow.com/a/75487519
         if not database.is_closed():
             database.close()
+        return response
+
+    # Middleware that injects camera metadata into all JSON responses
+    @app.middleware("http")
+    async def camera_meta_middleware(request: Request, call_next):
+        response = await call_next(request)
+        content_type = response.headers.get("content-type", "")
+        if content_type.startswith("application/json"):
+            try:
+                body_bytes = response.body
+            except Exception:
+                body_bytes = None
+            if body_bytes:
+                try:
+                    data = json.loads(body_bytes)
+                except Exception:
+                    return response
+
+                def inject_meta(obj):
+                    if isinstance(obj, dict):
+                        if "camera" in obj and "camera_meta" not in obj:
+                            camera_name = obj.get("camera")
+                            meta = {}
+                            try:
+                                camera_config = request.app.frigate_config.cameras.get(
+                                    camera_name
+                                )
+                                if (
+                                    camera_config is not None
+                                    and getattr(camera_config, "meta", None) is not None
+                                ):
+                                    meta = camera_config.meta or {}
+                            except Exception:
+                                meta = {}
+                            obj["camera_meta"] = meta
+                        for val in obj.values():
+                            inject_meta(val)
+                    elif isinstance(obj, list):
+                        for item in obj:
+                            inject_meta(item)
+
+                inject_meta(data)
+                return JSONResponse(content=data, status_code=response.status_code)
         return response
 
     @app.on_event("startup")

--- a/frigate/config/camera/camera.py
+++ b/frigate/config/camera/camera.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import Field, PrivateAttr
 
@@ -51,6 +51,14 @@ class CameraTypeEnum(str, Enum):
 class CameraConfig(FrigateBaseModel):
     name: Optional[str] = Field(None, title="Camera name.", pattern=REGEX_CAMERA_NAME)
     enabled: bool = Field(default=True, title="Enable camera.")
+
+    # Custom metadata for this camera. This field allows arbitrary key/value
+    # pairs to be stored in the configuration, such as camera serial
+    # numbers or installation information. Values must be JSON-serializable.
+    meta: dict[str, Any] = Field(
+        default_factory=dict,
+        title="Custom metadata for the camera. Keys and values are arbitrary.",
+    )
 
     # Options with global fallback
     audio: AudioConfig = Field(


### PR DESCRIPTION
## Summary
- allow custom metadata to be attached to cameras
- inject camera metadata into FastAPI JSON responses

## Testing
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python -m mypy --config-file frigate/mypy.ini frigate` *(fails: Library stubs not installed for "requests"; unused ignore comment)*
- `ruff check frigate/config/camera/camera.py frigate/api/fastapi_app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7c4bd8c848323b0a23736ecb33383