### PR TITLE
Ensure camera metadata is included in event responses

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -17,6 +17,7 @@ from peewee import JOIN, DoesNotExist, fn, operator
 from playhouse.shortcuts import model_to_dict
 
 from frigate.api.auth import require_role
+from frigate.api.utils import inject_camera_meta
 from frigate.api.defs.query.events_query_parameters import (
     DEFAULT_TIME_RANGE,
     EventsQueryParams,
@@ -56,7 +57,7 @@ router = APIRouter(tags=[Tags.events])
 
 
 @router.get("/events", response_model=list[EventResponse])
-def events(params: EventsQueryParams = Depends()):
+def events(request: Request, params: EventsQueryParams = Depends()):
     camera = params.camera
     cameras = params.cameras
 
@@ -323,11 +324,14 @@ def events(params: EventsQueryParams = Depends()):
         .iterator()
     )
 
-    return JSONResponse(content=list(events))
+    event_list = list(events)
+    inject_camera_meta(event_list, request.app.frigate_config)
+
+    return JSONResponse(content=event_list)
 
 
 @router.get("/events/explore", response_model=list[EventResponse])
-def events_explore(limit: int = 10):
+def events_explore(request: Request, limit: int = 10):
     # get distinct labels for all events
     distinct_labels = Event.select(Event.label).distinct().order_by(Event.label)
 
@@ -395,6 +399,8 @@ def events_explore(limit: int = 10):
         key=lambda x: (x["event_count"], x["start_time"]),
         reverse=True,
     )
+
+    inject_camera_meta(processed_events, request.app.frigate_config)
 
     return JSONResponse(content=processed_events)
 

--- a/frigate/api/fastapi_app.py
+++ b/frigate/api/fastapi_app.py
@@ -31,6 +31,7 @@ from frigate.embeddings import EmbeddingsContext
 from frigate.ptz.onvif import OnvifController
 from frigate.stats.emitter import StatsEmitter
 from frigate.storage import StorageMaintainer
+from frigate.api.utils import inject_camera_meta
 
 logger = logging.getLogger(__name__)
 
@@ -128,37 +129,7 @@ def create_fastapi_app(
             )
             return response
 
-        injected = False
-        found_camera = False
-
-        def inject_meta(obj):
-            nonlocal injected, found_camera
-            if isinstance(obj, dict):
-                if "camera" in obj:
-                    found_camera = True
-                    if "camera_meta" not in obj:
-                        camera_name = obj.get("camera")
-                        meta = {}
-                        try:
-                            camera_config = request.app.frigate_config.cameras.get(
-                                camera_name
-                            )
-                            if (
-                                camera_config is not None
-                                and getattr(camera_config, "meta", None) is not None
-                            ):
-                                meta = camera_config.meta or {}
-                        except Exception:
-                            meta = {}
-                        obj["camera_meta"] = meta
-                        injected = True
-                for val in obj.values():
-                    inject_meta(val)
-            elif isinstance(obj, list):
-                for item in obj:
-                    inject_meta(item)
-
-        inject_meta(data)
+        injected, found_camera = inject_camera_meta(data, request.app.frigate_config)
         if not injected:
             if found_camera:
                 logger.debug(

--- a/frigate/api/utils.py
+++ b/frigate/api/utils.py
@@ -1,0 +1,62 @@
+"""Utility helpers for Frigate API modules."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Tuple
+
+
+def inject_camera_meta(data: Any, frigate_config) -> Tuple[bool, bool]:
+    """Inject camera meta information into response payloads.
+
+    Args:
+        data: Arbitrary JSON-serialisable data structure containing event objects.
+        frigate_config: The active :class:`~frigate.config.FrigateConfig` instance.
+
+    Returns:
+        A tuple ``(injected, found_camera)`` indicating whether a ``camera_meta``
+        field was inserted and whether any ``camera`` fields were encountered
+        during traversal respectively.
+    """
+
+    injected = False
+    found_camera = False
+
+    def _inject(obj: Any) -> None:
+        nonlocal injected, found_camera
+
+        if isinstance(obj, dict):
+            if "camera" in obj:
+                found_camera = True
+
+                if "camera_meta" not in obj:
+                    camera_name = obj.get("camera")
+                    meta = {}
+
+                    try:
+                        camera_config = None
+                        if frigate_config is not None:
+                            camera_config = frigate_config.cameras.get(camera_name)
+
+                        if (
+                            camera_config is not None
+                            and getattr(camera_config, "meta", None) is not None
+                        ):
+                            meta = camera_config.meta or {}
+                    except Exception:
+                        meta = {}
+
+                    obj["camera_meta"] = meta
+                    injected = True
+
+            for value in obj.values():
+                _inject(value)
+
+        elif isinstance(obj, Iterable) and not isinstance(obj, (str, bytes, bytearray)):
+            for item in obj:
+                _inject(item)
+
+    _inject(data)
+
+    return injected, found_camera
+


### PR DESCRIPTION
## Summary
- add a reusable helper to inject camera metadata into nested JSON payloads
- ensure the `/api/events` and `/api/events/explore` endpoints enrich each event with camera metadata before responding
- reuse the helper inside the camera metadata middleware for consistent behaviour

## Testing
- python -m compileall frigate/api

------
https://chatgpt.com/codex/tasks/task_b_68db5a0708b4832393af9ba4e66cb2fc